### PR TITLE
fix: Updates wiremock version

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.9.2</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updates wiremock to 3.10.0 to avoid digg quarantine policy violation: http://displniq0001.digg.se:8081/assets/index.html#/repositories/quarantinedComponent/NTE0ZWE4MTdkMjIyNDc4MWEwNjBjOGY3MTg5MTRlMjU